### PR TITLE
The GetSystemTimeAsFileTime API is crucial for the monitor to cap API…

### DIFF
--- a/cape/cape_main.py
+++ b/cape/cape_main.py
@@ -105,7 +105,6 @@ SILENCED_APIS = [
     "GetCursorPos",
     "GetLastInputInfo",
     "GetSystemTime",
-    "GetSystemTimeAsFileTime",
     "LdrGetProcedureAddressForCaller",
     "MsgWaitForMultipleObjectsEx",
     "NtDeviceIoControlFile",


### PR DESCRIPTION
… limits

This should actually close this ticket https://cccs.atlassian.net/browse/AL-1896