### PR TITLE
Extracting IOCs from HTTP Headers

### DIFF
--- a/cape/cape_result.py
+++ b/cape/cape_result.py
@@ -596,6 +596,9 @@ def process_network(
             )
             _ = add_tag(http_sec, "network.dynamic.uri", http_call.request_uri, safelist)
 
+            for _, value in http_call.request_headers.items():
+                extract_iocs_from_text_blob(value, http_sec)
+
             # Now we're going to try to detect if a remote file is attempted to be downloaded over HTTP
             if http_call.request_method == "GET":
                 split_path = http_call.request_uri.rsplit("/", 1)


### PR DESCRIPTION
Sometimes there are IOCs stored in the headers that are not tagged. This will tag them.


![image](https://user-images.githubusercontent.com/59843993/199093794-b5ab2029-cd0e-4a67-a73f-1ff55350b584.png)
![image](https://user-images.githubusercontent.com/59843993/199093855-d4928878-c5e4-4898-91e9-7acd9343c3f1.png)
