### PR TITLE
Capitalizing the platform to match the ODM regex

### DIFF
--- a/cape/cape_result.py
+++ b/cape/cape_result.py
@@ -362,7 +362,7 @@ def process_machine_info(machine_info: Dict[str, Any], ontres: OntologyResults):
     machine_name = machine_info["Name"]
     sandbox.update_machine_metadata(
         hostname=machine_name,
-        platform=machine_info["Platform"],
+        platform=machine_info["Platform"].capitalize(),
         ip=machine_info["IP"],
         hypervisor=machine_info["Manager"],
     )


### PR DESCRIPTION
This should stop the "Problem applying data to given model: [platform] 'windows' not match the validator: ^(Windows|Linux|MacOS|Android|iOS)$" message