### PR TITLE
Adding ability to submit to antivm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,17 @@ The method for interpretting this structure is that files are divided between Li
 * **token_key** - [default: Token] This the default keyword for the Django Rest Framework.
 If you change it on the CAPE REST API, change this value to reflect that new value.
 
-####
+#### If the desired machine is not present in the configuration, sleep and try again?
 * **retry_on_no_machine** - [default: False] If your CAPE machinery deletes machines, (AWS/Azure), there is a chance that a certain machine may not be present
 for a period of time. This configuration will raise a RecoverableError in that situation, after sleeping for a certain
 time period.
 
-####
+#### Too many monitor logs?
 * **limit_monitor_apis** - [default: False] Apply a limit of 1000 to APIs that the CAPE monitor logs.
+
+#### Should we setup the VM prior to sample execution by opening a few applications?
+Note that this is only applicable to samples that would use the `doc` and `js` packages normally.
+* **use_antivm_packages** - [default: False] Start some applications prior to execution.
 
 ### CAPE Submission Options
 

--- a/cape/cape_main.py
+++ b/cape/cape_main.py
@@ -1314,7 +1314,6 @@ class CAPE(ServiceBase):
         # NOTE: CAPE still tries to identify files itself, so we only force the extension/package
         # if the user specifies one. However, we go through the trouble of renaming the file because
         # the only way to have certain modules run is to use the appropriate suffix (.jar, .vbs, etc.)
-        # TODO: Adapt to be able to match packages found in https://github.com/kevoreilly/CAPEv2/blob/master/analyzer/windows/lib/core/packages.py
 
         # Check for a valid tag
         # TODO: this should be more explicit in terms of "unknown" in file_type
@@ -1331,8 +1330,6 @@ class CAPE(ServiceBase):
                 )
                 return ""
             else:
-                if submitted_ext == "bin":
-                    kwargs["package"] = "bin"
                 # This is a usable extension. It might not run (if the submitter has lied to us).
                 file_ext = "." + submitted_ext
         else:
@@ -1398,8 +1395,14 @@ class CAPE(ServiceBase):
         elif self.request.file_type in ["archive/iso", "archive/vhd", "archive/udf", "archive/zip"]:
             task_options.append("file=")
 
+        # Package-related logic
+        # If the user requests a package, give it to them
         if package:
             kwargs["package"] = package
+        # If the user wants to use antivm packages and the file type makes sense, give it to them
+        elif self.config.get("use_antivm_packages", False) and self.request.file_type in ["code/javascript", "document/office/word"]:
+            # Assign the appropriate package based on file type. As of 2022-11-25, there are only two.
+            kwargs["package"] = "doc_antivm" if self.request.file_type == "document/office/word" else "js_antivm"
 
         if arguments:
             task_options.append(f"arguments={arguments}")

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -2,7 +2,7 @@ name: CAPE
 version: $SERVICE_TAG
 description: Provides dynamic malware analysis through sandboxing.
 
-accepts: (executable/(windows|linux)|java|audiovisual|meta)/.*|document/(installer/windows|office/(excel|ole|powerpoint|rtf|unknown|word|mhtml)|pdf$)|code/(javascript|jscript|python|vbs|wsf|html|ps1|batch|hta)|shortcut/windows|archive/(iso|vhd|udf|zip)
+accepts: (executable/(windows|linux)|java|audiovisual|meta)/.*|document/(installer/windows|office/(excel|ole|powerpoint|rtf|unknown|word|mhtml)|pdf$)|code/(javascript|jscript|python|vbs|wsf|html|ps1|batch|hta)|shortcut/windows|archive/(chm/iso|vhd|udf|zip)
 rejects: empty|metadata/.*
 
 stage: CORE
@@ -68,6 +68,9 @@ config:
 
   # Apply a limit of 1000 to APIs that the CAPE monitor logs (normally this value is 5000).
   limit_monitor_apis: false
+
+  # Use the "antivm" packages for winword.exe and wscript.exe, which open a few applications prior to execution in the VM
+  use_antivm_packages: false
 
 submission_params:
   - default: 0

--- a/tests/test_cape_main.py
+++ b/tests/test_cape_main.py
@@ -1368,8 +1368,6 @@ class TestCapeMain:
                 assert cape_class_instance.file_name == correct_file_name
                 return
             else:
-                if submitted_ext == "bin":
-                    is_bin = True
                 file_ext = '.' + submitted_ext
         else:
             assert cape_class_instance._assign_file_extension(kwargs) == ""


### PR DESCRIPTION
Relevant to https://github.com/kevoreilly/CAPEv2/pull/1259
Partially addressing https://cccs.atlassian.net/browse/AL-1966

- Removing TODO since I'M WORKING ON IT
- There is no `bin` package in CAPE
- Adding acceptance for `archive/chm`