### PR TITLE
Making it optional to include the dump_memory param

### DIFF
--- a/cape/cape_main.py
+++ b/cape/cape_main.py
@@ -1369,7 +1369,7 @@ class CAPE(ServiceBase):
                 "default_analysis_timeout_in_seconds", ANALYSIS_TIMEOUT
             )
         arguments = self.request.get_param("arguments")
-        dump_memory = self.request.get_param("dump_memory")
+        dump_memory = self._safely_get_param("dump_memory")
         no_monitor = self.request.get_param("no_monitor")
 
         # If the user didn't select no_monitor, but at the service level we want no_monitor on Windows 10x64, then:


### PR DESCRIPTION
So that we can delete it from the submission parameters in the UI if memory dumps are not supported