### PR TITLE
 Update cape_result.py to reflect the type issue between times

### DIFF
--- a/cape/cape_result.py
+++ b/cape/cape_result.py
@@ -757,7 +757,7 @@ def _link_flow_with_process(
     elif network_flow["image"] == UNKNOWN_PROCESS:
         p = ontres.get_process_by_guid(network_flow.get("guid"))
         if isinstance(network_flow.get("timestamp"), float):
-            timestamp = epoch_to_local_with_ms(network_flow.get("timestamp"))
+            timestamp = epoch_to_local_with_ms(network_flow["timestamp"])
         else:
             timestamp = network_flow.get("timestamp")
         if not p:

--- a/cape/cape_result.py
+++ b/cape/cape_result.py
@@ -756,8 +756,12 @@ def _link_flow_with_process(
     # Special handling for when Sysmon gives us process-related details but cannot get the image name
     elif network_flow["image"] == UNKNOWN_PROCESS:
         p = ontres.get_process_by_guid(network_flow.get("guid"))
+        if isinstance(network_flow.get("timestamp"), float):
+            timestamp = epoch_to_local_with_ms(network_flow.get("timestamp"))
+        else:
+            timestamp = network_flow.get("timestamp")
         if not p:
-            p = ontres.get_process_by_pid_and_time(network_flow.get("pid"), network_flow.get("timestamp"))
+            p = ontres.get_process_by_pid_and_time(network_flow.get("pid"), timestamp)
 
         if p:
             network_flow["image"] = p.image


### PR DESCRIPTION
and timestamp <= process.end_time
TypeError: '<=' not supported between instances of 'float' and 'str'